### PR TITLE
Add allowUndefinedInResolve

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -62,6 +62,7 @@ app.get('/logout', (req, res) => {
 const executableSchema = makeExecutableSchema({
   typeDefs: schema,
   resolvers,
+  allowUndefinedInResolve: true,
 });
 
 app.use('/graphql', apolloExpress((req) => {


### PR DESCRIPTION
This used to be in GitHunt, and it's necessary so currentUser doesn't throw an error when it's undefined.