### PR TITLE
Avoiding Knex warning about default values.

### DIFF
--- a/knexfile.js
+++ b/knexfile.js
@@ -6,7 +6,8 @@ module.exports = {
     client: 'sqlite3',
     connection: {
       filename: './dev.sqlite3'
-    }
+    },
+    useNullAsDefault: true
   },
   //
   // staging: {


### PR DESCRIPTION
Whenever I run `npm run migrate`, `npm run seed` or `npm start` this warning appears:

```
Knex:warning - sqlite does not support inserting default values. Set the `useNullAsDefault` flag to hide this warning. (see docs http://knexjs.org/#Builder-insert).
```

I've set the `useNullAsDefault` key as true.